### PR TITLE
Ensure app.log file is created before configuring logger

### DIFF
--- a/flask-server/server.py
+++ b/flask-server/server.py
@@ -12,7 +12,8 @@ app = Flask(__name__)
 app.config.from_object(DevConfig)
 CORS(app, supports_credentials=True)
 
-logging.basicConfig(filename='flask-server/app.log', level=logging.DEBUG)
+open(file='./app.log', mode="w").close()
+logging.basicConfig(filename='./app.log', level=logging.DEBUG)
 
 db.init_app(app)
 api = Api(app,doc='/docs')


### PR DESCRIPTION
Clear app.log file if it exists, and create it if it doesn't.